### PR TITLE
Ignore base branch merge PR updates

### DIFF
--- a/slack_github_pr/github.py
+++ b/slack_github_pr/github.py
@@ -47,7 +47,7 @@ class GithubHandler(object):
         compare = self.api_request(url)
         if compare is None or compare['behind_by'] > 0 or compare['total_commits'] == 0:
             return True
-        return not commit['commits'][-1]['commit']['message'].startswith('Merge branch')
+        return not compare['commits'][-1]['commit']['message'].startswith('Merge branch')
 
     def build_message(self, action_desc):
         self.message = "{} {} {} {}#{}: {} (<{}|Open>)".format(


### PR DESCRIPTION
Slack notifications will no longer be sent when updating a Pull Request with the base branch
![image](https://user-images.githubusercontent.com/425209/44717795-53b9e500-aabe-11e8-97af-628b38d2a0cd.png)
